### PR TITLE
Replace deprecated remote import path

### DIFF
--- a/json.go
+++ b/json.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 )
 
 func RenderDataAsJSON(w http.ResponseWriter, data interface{}, err error, httpStatus int, httpErrorStatus int) {


### PR DESCRIPTION
Might not be necessary, but `go get github.com/Indivizo/go-utils` gave me errors regarding the import path. This seems to fix it.
